### PR TITLE
Hotfix for help menu alignment

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -47,7 +47,6 @@ jQuery(document).ready(function($) {
 	function hideDropdown() {
 		if ( helpMenuIsVisible ) {
 			$('#helpdropdown').fadeOut('600');
-			$('#helpdropdown').removeClass('right');
 			helpMenuIsVisible = false;
 		}
 	}


### PR DESCRIPTION
This fixes an issue with the help menu placement which was probably caused by disabling joyride. Also included in this hotfix is a simple fix for the jumpy triangle which has been a minor annoyance for a while. 
